### PR TITLE
Add matomo tracking to the Zom.im landing page.

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -1,4 +1,20 @@
-<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta http-equiv="X-UA-Compatible" content="IE=edge"><meta name="viewport" content="width=device-width,initial-scale=1"><link rel="icon" href="favicon.ico"><link href="https://fonts.googleapis.com/css2?family=Titillium+Web:ital,wght@0,300;0,400;0,700;1,300&display=swap" rel="stylesheet"><title>Zom Chat</title><link href="css/chunk-a6618d78.278eabe0.css" rel="prefetch"><link href="css/chunk-b8c12378.ef5e9573.css" rel="prefetch"><link href="css/chunk-eca06750.e9ec6cbd.css" rel="prefetch"><link href="js/chunk-a6618d78.a7ccf46a.js" rel="prefetch"><link href="js/chunk-b8c12378.0e81dfc0.js" rel="prefetch"><link href="js/chunk-eca06750.e00a5e86.js" rel="prefetch"><link href="css/app.6ef5a002.css" rel="preload" as="style"><link href="css/chunk-vendors.7e44a91e.css" rel="preload" as="style"><link href="js/app.0191217a.js" rel="preload" as="script"><link href="js/chunk-vendors.419ebd2c.js" rel="preload" as="script"><link href="css/chunk-vendors.7e44a91e.css" rel="stylesheet"><link href="css/app.6ef5a002.css" rel="stylesheet"></head><body><noscript><strong>We're sorry but Zom Chat doesn't work properly without JavaScript enabled. Please enable it to continue.</strong></noscript><div id="app"></div><script src="js/chunk-vendors.419ebd2c.js"></script><script src="js/app.0191217a.js"></script><!-- Global site tag (gtag.js) - Google Analytics -->
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta http-equiv="X-UA-Compatible" content="IE=edge"><meta name="viewport" content="width=device-width,initial-scale=1"><link rel="icon" href="favicon.ico"><link href="https://fonts.googleapis.com/css2?family=Titillium+Web:ital,wght@0,300;0,400;0,700;1,300&display=swap" rel="stylesheet"><title>Zom Chat</title><link href="css/chunk-a6618d78.278eabe0.css" rel="prefetch"><link href="css/chunk-b8c12378.ef5e9573.css" rel="prefetch"><link href="css/chunk-eca06750.e9ec6cbd.css" rel="prefetch"><link href="js/chunk-a6618d78.a7ccf46a.js" rel="prefetch"><link href="js/chunk-b8c12378.0e81dfc0.js" rel="prefetch"><link href="js/chunk-eca06750.e00a5e86.js" rel="prefetch"><link href="css/app.6ef5a002.css" rel="preload" as="style"><link href="css/chunk-vendors.7e44a91e.css" rel="preload" as="style"><link href="js/app.0191217a.js" rel="preload" as="script"><link href="js/chunk-vendors.419ebd2c.js" rel="preload" as="script"><link href="css/chunk-vendors.7e44a91e.css" rel="stylesheet"><link href="css/app.6ef5a002.css" rel="stylesheet"></head><body><noscript><strong>We're sorry but Zom Chat doesn't work properly without JavaScript enabled. Please enable it to continue.</strong></noscript><div id="app"></div><script src="js/chunk-vendors.419ebd2c.js"></script><script src="js/app.0191217a.js"></script>
+  <!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="//zom.im/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '17']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Code -->
+<!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-9EJ9C8LBS2"></script>
 <script>
   window.dataLayer = window.dataLayer || [];

--- a/download/index.html
+++ b/download/index.html
@@ -11,6 +11,21 @@
     <link rel="stylesheet" href="css/app.css">
   <link href="css/zmcs.css" rel="stylesheet" type="text/css">
   <link href="css/animate.css" rel="stylesheet" type="text/css">
+<!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="//zom.im/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '17']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Code -->
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-9EJ9C8LBS2"></script>
 <script>

--- a/i/index.html
+++ b/i/index.html
@@ -28,6 +28,21 @@ padding:12px;
     <!-- Modernizr Scripts -->
     <script src="javascript/vendor/modernizr-2.7.1.min.js"></script>
     <script src="javascript/wechat.js"></script>
+<!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="//zom.im/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '17']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Code -->
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-9EJ9C8LBS2"></script>
 <script>

--- a/i/index2.html
+++ b/i/index2.html
@@ -28,6 +28,21 @@ padding:12px;
     <!-- Modernizr Scripts -->
     <script src="javascript/vendor/modernizr-2.7.1.min.js"></script>
     <script src="javascript/wechat.js"></script>
+<!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="//zom.im/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '17']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Code -->
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-9EJ9C8LBS2"></script>
 <script>

--- a/i/index_chinese.html
+++ b/i/index_chinese.html
@@ -28,6 +28,21 @@ padding:12px;
     <!-- Modernizr Scripts -->
     <script src="javascript/vendor/modernizr-2.7.1.min.js"></script>
     <script src="javascript/wechat.js"></script>
+<!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="//zom.im/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '17']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Code -->
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-9EJ9C8LBS2"></script>
 <script>

--- a/i/index_tibetan.html
+++ b/i/index_tibetan.html
@@ -28,6 +28,21 @@ padding:12px;
     <!-- Modernizr Scripts -->
     <script src="javascript/vendor/modernizr-2.7.1.min.js"></script>
     <script src="javascript/wechat.js"></script>
+<!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="//zom.im/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '17']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Code -->
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-9EJ9C8LBS2"></script>
 <script>

--- a/index.html
+++ b/index.html
@@ -11,6 +11,21 @@
   <link href="css/zmcs.css" rel="stylesheet" type="text/css">
   <link href="css/animate.css" rel="stylesheet" type="text/css">
 
+<!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="//zom.im/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '17']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Code -->
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-9EJ9C8LBS2"></script>
 <script>

--- a/zomabout.html
+++ b/zomabout.html
@@ -10,6 +10,21 @@
     <link rel="stylesheet" href="css/app.css">
   <link href="css/zmcs.css" rel="stylesheet" type="text/css">
   <link href="css/animate.css" rel="stylesheet" type="text/css">
+<!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="//zom.im/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '17']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Code -->
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-9EJ9C8LBS2"></script>
 <script>

--- a/zomchinese.html
+++ b/zomchinese.html
@@ -10,6 +10,21 @@
     <link rel="stylesheet" href="css/app.css">
   <link href="css/zmcs.css" rel="stylesheet" type="text/css">
   <link href="css/animate.css" rel="stylesheet" type="text/css">
+<!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="//zom.im/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '17']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Code -->
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-9EJ9C8LBS2"></script>
 <script>


### PR DESCRIPTION
Anywhere google analytics (via gtag 'G-9EJ9C8LBS2') appears in this repo, also add matomo.js sourced from zom.im.

This does not add matomo tracking to the Zom apps (web, iOS or android).